### PR TITLE
Update scrypto deps to 1.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ description = "Math library extending Radix Scrypto with more advanced mathemati
 repository = "https://github.com/ociswap/scrypto-math"
 
 [dependencies]
-radix-rust = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-9396c507" }
-radix-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-9396c507" }
-radix-common-derive = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-9396c507" }
+radix-rust = "1.2.0"
+radix-common = "1.2.0"
+radix-common-derive = "1.2.0"
 num-traits = "0.2.19"
 pretty_assertions = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ description = "Math library extending Radix Scrypto with more advanced mathemati
 repository = "https://github.com/ociswap/scrypto-math"
 
 [dependencies]
-utils = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v1.1.1", version = "1.1.1" }
-radix-engine-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v1.1.1", version = "1.1.1" }
-radix-engine-macros = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v1.1.1", version = "1.1.1" }
+radix-rust = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-9396c507" }
+radix-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-9396c507" }
+radix-common-derive = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "bottlenose-9396c507" }
 num-traits = "0.2.15"
 pretty_assertions = "1.4.0"

--- a/src/exponential.rs
+++ b/src/exponential.rs
@@ -61,8 +61,8 @@
  */
 
 use num_traits::ToPrimitive;
-use radix_engine_common::math::{Decimal, PreciseDecimal};
-use radix_engine_macros::{dec, pdec};
+use radix_common::math::{Decimal, PreciseDecimal};
+use radix_common_derive::{dec, pdec};
 
 const LN2: PreciseDecimal = pdec!("0.693147180559945309417232121458176568");
 const HALF_POSITIVE: PreciseDecimal = pdec!("0.5");

--- a/src/logarithm.rs
+++ b/src/logarithm.rs
@@ -59,8 +59,8 @@
  */
 
 use num_traits::Zero;
-use radix_engine_common::math::{Decimal, PreciseDecimal};
-use radix_engine_macros::pdec;
+use radix_common::math::{Decimal, PreciseDecimal};
+use radix_common_derive::pdec;
 
 const LN2: PreciseDecimal = pdec!("0.693147180559945309417232121458176568");
 const LN10: PreciseDecimal = pdec!("2.302585092994045684017991454684364207");
@@ -209,7 +209,7 @@ impl LogarithmPreciseDecimal for PreciseDecimal {
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
-    use radix_engine_macros::dec;
+    use radix_common_derive::dec;
 
     #[test]
     fn test_constants() {

--- a/src/power.rs
+++ b/src/power.rs
@@ -55,8 +55,8 @@
 use crate::exponential::ExponentialPreciseDecimal;
 use crate::logarithm::LogarithmPreciseDecimal;
 use num_traits::ToPrimitive;
-use radix_engine_common::math::{CheckedMul, Decimal, PreciseDecimal};
-use radix_engine_macros::pdec;
+use radix_common::math::{CheckedMul, Decimal, PreciseDecimal};
+use radix_common_derive::pdec;
 
 pub trait PowerDecimal {
     fn pow(&self, exp: Decimal) -> Option<Decimal>;
@@ -131,7 +131,7 @@ impl PowerPreciseDecimal for PreciseDecimal {
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
-    use radix_engine_macros::dec;
+    use radix_common_derive::dec;
 
     #[test]
     fn test_pow_exp_zero() {


### PR DESCRIPTION
This PR updates `scrypto-math` with latest Radix Engine changes for recently released `scrypto 1.2.0`.

