### PR TITLE
Error Estimates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ build/
 *.egg-info/
 __pycache__/
 dist/
+
+venv/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,7 @@ radix-rust = "1.2.0"
 radix-common = "1.2.0"
 radix-common-derive = "1.2.0"
 num-traits = "0.2.19"
+
+[dev-dependencies]
 pretty_assertions = "1.4.0"
+test-case = "3"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ error_exp(value) = 2^k * error_exp_r = 2^k * 2^-59 = 2^(k - 59)
 Overall this provides an approximation error lower than ~ 18 significant digits. However, the error can overflow to the next digits, meaning this is no guarantee.
 Only the maximum error can be guaranteed, but not the significant digits.
 
-The Python library `scryptomath` provides the function [error_exp](python/scryptomath.py#user-content-error_exp)  to estimate the maximum error for a specific value.
+The Python library `scryptomath` provides the function [error_exp](python/scryptomath.py) to estimate the maximum error for a specific value.
 
 ### Logarithm Function
 Logarithm is available for `Decimal` and `PreciseDecimal`. with a maximum polynomial approximation error bound by `2**-58.45` (~ `2.6*10**-18`).
@@ -76,7 +76,7 @@ You can see a full blueprint example including tests here [AdvancedMathDemo](exa
 #### Error Estimation
 The maximum polynomial approximation error is bound by the constant `2**-58.45` (~ `2.6*10**-18`).
 
-The Python library `scryptomath` provides the function [error_ln](python/scryptomath.py#user-content-error_ln) giving the maximum error.
+The Python library `scryptomath` provides the function [error_ln](python/scryptomath.py) giving the maximum error.
 
 ### Power Function
 The power function internally uses both `exp` and `ln` and also covers various special cases like `0**0` or `-2**3`.
@@ -128,7 +128,7 @@ Resulting in:
 error_pow(x, y) = error_exp(ln(x) * y) + e^(ln(x) * y) * error_ln * y
 ```
 
-The Python library `scryptomath` provides the function [error_pow](python/scryptomath.py#user-content-error_pow) to estimate the maximum error for a specific value.
+The Python library `scryptomath` provides the function [error_pow](python/scryptomath.py) to estimate the maximum error for a specific value.
 
 ## Contributions
 We are happy to collaborate and review and merge pull requests :)

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ You can see a full blueprint example including tests here [AdvancedMathDemo](exa
 #### Error Estimation
 The Approxmation error of `exp_r(r)` is bound by `2^-59 ~ 1.8*10^-18` with reduced argument `r` of `x`.
 
-```
+```txt
 e^x = 2^k * exp_r'(r)                         with k determined by the argument reduction
 e^x = 2^k * (exp_r(r) + error_exp_r)
 e^x = 2^k * exp_r(r) + 2^k * error_exp_r
 e^x = 2^k * exp_r(r) + error_exp
 ```
 Resulting in:
-```
+```txt
 error_exp(value) = 2^k * error_exp_r = 2^k * 2^-59 = 2^(k - 59)
 ```
 
@@ -124,7 +124,7 @@ e'^(ln(x) * y + error_ln * y)
 ```
 
 Resulting in:
-```
+```txt
 error_pow(x, y) = error_exp(ln(x) * y) + e^(ln(x) * y) * error_ln * y
 ```
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Resulting in:
 error_pow(x, y) = error_exp(ln(x) * y) + e^(ln(x) * y) * error_ln * y
 ```
 
-The Python library `scryptomath` provides the function [error_pow](python/scryptomath.py) to estimate the maximum error for a specific value.
+The Python library `scryptomath` provides the function [error_pow](python/scryptomath.py) to estimate the maximum error for specific values.
 
 ## Contributions
 We are happy to collaborate and review and merge pull requests :)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ let exp: Option<PreciseDecimal> = pdec!(4).exp();
 You can see a full blueprint example including tests here [AdvancedMathDemo](examples/advanced_math/src/lib.rs).
 
 #### Error Estimation
-The Approxmation error of `exp_r(r)` is bound by `2^-59 ~ 2*10^-18` with reduced argument `r` of `x`.
+The Approxmation error of `exp_r(r)` is bound by `2^-59 ~ 1.8*10^-18` with reduced argument `r` of `x`.
 
 ```
 e^x = 2^k * exp_r'(r)                         with k determined by the argument reduction

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ use scrypto_math::*;
 ## Featues
 
 ### Exponential Function
-The exponential function is provided for `Decimal` and `PreciseDecimal` with a polynomial approximation error lower than ~ 18 significant digits.
-Background: the final result is calculated via `exp(x) = 2**k * R(r)` and the approximation `R(r)` is bound by an maximum error of `2**-59` (~ 18 decimal places).
+The exponential function is provided for `Decimal` and `PreciseDecimal`.
 
 For `Decimal`:
 ```rust
@@ -34,8 +33,27 @@ let exp: Option<PreciseDecimal> = pdec!(4).exp();
 
 You can see a full blueprint example including tests here [AdvancedMathDemo](examples/advanced_math/src/lib.rs).
 
+#### Error Estimation
+The Approxmation error of `exp_r(r)` is bound by `2^-59 ~ 2*10^-18` with reduced argument `r` of `x`.
+
+```
+e^x = 2^k * exp_r'(r)                         with k determined by the argument reduction
+e^x = 2^k * (exp_r(r) + error_exp_r)
+e^x = 2^k * exp_r(r) + 2^k * error_exp_r
+e^x = 2^k * exp_r(r) + error_exp
+```
+Resulting in:
+```
+error_exp(value) = 2^k * error_exp_r = 2^k * 2^-59 = 2^(k - 59)
+```
+
+Overall this provides an approximation error lower than ~ 18 significant digits. However, the error can overflow to the next digits, meaning this is no guarantee.
+Only the maximum error can be guaranteed, but not the significant digits.
+
+The Python library `scryptomath` provides the function [error_exp](python/scryptomath.py#user-content-error_exp)  to estimate the maximum error for a specific value.
+
 ### Logarithm Function
-Logarithm is available for `Decimal` and `PreciseDecimal` with a maximum polynomial approximation error bound by `2**-58.45` (~ 18 decimal places).
+Logarithm is available for `Decimal` and `PreciseDecimal`. with a maximum polynomial approximation error bound by `2**-58.45` (~ `2.6*10**-18`).
 
 For `Decimal`:
 ```rust
@@ -55,6 +73,11 @@ let log8: Option<PreciseDecimal> = pdec!(5).log_base(base: pdec!(8));
 
 You can see a full blueprint example including tests here [AdvancedMathDemo](examples/advanced_math/src/lib.rs).
 
+#### Error Estimation
+The maximum polynomial approximation error is bound by the constant `2**-58.45` (~ `2.6*10**-18`).
+
+The Python library `scryptomath` provides the function [error_ln](python/scryptomath.py#user-content-error_ln) giving the maximum error.
+
 ### Power Function
 The power function internally uses both `exp` and `ln` and also covers various special cases like `0**0` or `-2**3`.
 
@@ -69,6 +92,43 @@ let pow: Option<PreciseDecimal> = pdec!("3.14").pow("-45.97");
 ```
 
 You can see a full blueprint example including tests here [AdvancedMathDemo](examples/advanced_math/src/lib.rs).
+
+#### Error Estimation
+Calculation of `pow` is based on `exp` and `ln`:
+```txt
+x^y = e^(ln(x) * y)
+```
+
+Accounting for approximation errors gives:
+```txt
+e'^(ln'(x) * y)
+= e'^((ln(x) + error_ln) * y)
+= e'^(ln(x) * y + error_ln * y)
+```
+
+Using Taylor expansion we can approximate `e^(x+error)` for `|error| << 1 with: e^(n + error) ~ e^n + e^n * error`.
+`e'(n)` and `ln'(n)` represent the exponential and logarithmic function with approximation error.
+
+Even with an unreasonable large exponent like `y=10^6`, we'd still get:
+```txt
+error_ln * y ≈ (3×10^-18) * 10^6 = 3×10^-12
+```
+which is much smaller than one.
+
+Allowing to separate the error term:
+```txt
+e'^(ln(x) * y + error_ln * y)
+~ e'^(ln(x) * y) + e^(ln(x) * y) * error_ln * y
+= e^(ln(x) * y) + error_exp(ln(x) * y) + e^(ln(x) * y) * error_ln * y
+= e^(ln(x) * y) + error_pow(x, y)
+```
+
+Resulting in:
+```
+error_pow(x, y) = error_exp(ln(x) * y) + e^(ln(x) * y) * error_ln * y
+```
+
+The Python library `scryptomath` provides the function [error_pow](python/scryptomath.py#user-content-error_pow) to estimate the maximum error for a specific value.
 
 ## Contributions
 We are happy to collaborate and review and merge pull requests :)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scryptomath"
-version = "0.0.5"
+version = "0.0.6"
 description = "Math library to support writing Python tests for Scrypto blueprints"
 readme = "README.md"
 authors = [{ name = "Ociswap", email = "dev@ociswap.com" }]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "scryptomath"
-version = "0.0.4"
+version = "0.0.5"
 description = "Math library to support writing Python tests for Scrypto blueprints"
 readme = "README.md"
 authors = [{ name = "Ociswap", email = "dev@ociswap.com" }]

--- a/python/scryptomath.py
+++ b/python/scryptomath.py
@@ -139,9 +139,11 @@ def relative_error(result: decimal.Decimal, error: decimal.Decimal):
 
 def error_ln() -> decimal.Decimal:
     """
-    Approximation error of `ln` is bound by 2^-58.45 ~ 2.6*10^-18.
+    Approximation error of `ln` is bound by `2^-58.45 ~ 2.6*10^-18`.
 
+    ```txt
     error_ln = 2^-58.45 ~ 2.6*10^-18
+    ```
     """
     with localcontext() as context:
         context.prec = 40
@@ -150,9 +152,9 @@ def error_ln() -> decimal.Decimal:
 
 def error_exp(value: decimal.Decimal) -> decimal.Decimal:
     """
-    Approxmation error of exp_r(r) is bound by 2^-59 ~ 1.8*10^-18 with reduced argument r of x.
+    Approxmation error of exp_r(r) is bound by `2^-59 ~ 1.8*10^-18` with reduced argument `r` of `x`.
 
-    ```
+    ```txt
     e^x = 2^k * exp_r'(r)                         with k determined by the argument reduction
     e^x = 2^k * (exp_r(r) + error_exp_r)
     e^x = 2^k * exp_r(r) + 2^k * error_exp_r
@@ -204,7 +206,7 @@ def error_pow(base: decimal.Decimal, exp: decimal.Decimal) -> decimal.Decimal:
     ```
 
     Resulting in:
-    ```
+    ```txt
     error_pow(x, y) = error_exp(ln(x) * y) + e^(ln(x) * y) * error_ln * y
     ```
     """

--- a/python/scryptomath.py
+++ b/python/scryptomath.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
 from typing import Union
 import decimal
+from decimal import localcontext
 
 
 decimal.getcontext().prec = 500
@@ -128,3 +129,83 @@ class PreciseDecimal(ScryptoBaseDecimal):
 
     def floor_to_decimal(self) -> "Decimal":
         return Decimal._cast(self)
+
+
+def relative_error(result: decimal.Decimal, error: decimal.Decimal):
+    with localcontext() as context:
+        context.prec = 40
+        return abs(error) / abs(result)
+
+
+def error_ln() -> decimal.Decimal:
+    """
+    Approximation error of `ln` is bound by 2^-58.45 ~ 3*10^-18.
+
+    error_ln = 2^-58.45 ~ 3*10^-18
+    """
+    with localcontext() as context:
+        context.prec = 40
+        return decimal.Decimal(2) ** decimal.Decimal("-58.45")
+
+
+def error_exp(value: decimal.Decimal) -> decimal.Decimal:
+    """
+    Approxmation error of exp_r(r) is bound by 2^-59 ~ 2*10^-18 with reduced argument r of x.
+
+    ```
+    e^x = 2^k * exp_r'(r)                         with k determined by the argument reduction
+    e^x = 2^k * (exp_r(r) + error_exp_r)
+    e^x = 2^k * exp_r(r) + 2^k * error_exp_r
+    e^x = 2^k * exp_r(r) + error_exp
+
+    error_exp(value) = 2^k * error_exp_r = 2^k * 2^-59 = 2^(k - 59)
+    ```
+    """
+    with localcontext() as context:
+        context.prec = 40
+        signed_half = (
+            decimal.Decimal("-0.5")
+            if value < decimal.Decimal(0)
+            else decimal.Decimal("0.5")
+        )
+        k = int((value / decimal.Decimal(2).ln() + signed_half))
+        return decimal.Decimal(2) ** (k - 59)
+
+
+def error_pow(base: decimal.Decimal, exp: decimal.Decimal) -> decimal.Decimal:
+    """
+    Calculatiion of `pow` is based on `exp` and `ln`:
+    ```txt
+    x^y = e^(ln(x) * y)
+    ```
+
+    Accounting for approximation errors gives:
+    ```txt
+    e'^(ln'(x) * y)
+    = e'^((ln(x) + error_ln) * y)
+    = e'^(ln(x) * y + error_ln * y)
+    ```
+
+    Using Taylor expansion we can approximate e^(x+error) for |error| << 1 with: e^(n + error) ~ e^n + e^n * error.
+    e'(n) and ln'(n) represent the exponential and logarithmic function with approximation error.
+
+    Even with an unreasonable large exponent like y=10^6, we'd still get:
+    ```txt
+    error_ln * y ≈ (3×10^-18) * 10^6 = 3×10^-12
+    ```
+    which is much smaller than one.
+
+    Resulting in:
+    ```txt
+    e'^(ln(x) * y + error_ln * y)
+    ~ e'^(ln(x) * y) + e^(ln(x) * y) * error_ln * y
+    = e^(ln(x) * y) + error_exp(ln(x) * y) + e^(ln(x) * y) * error_ln * y
+    = e^(ln(x) * y) + error_pow(x, y)
+
+    error_pow(x, y) = error_exp(ln(x) * y) + e^(ln(x) * y) * error_ln * y
+    ```
+    """
+    with localcontext() as context:
+        context.prec = 40
+        e_exp = base.ln() * exp
+        return error_exp(e_exp) + e_exp.exp() * error_ln() * exp

--- a/python/scryptomath.py
+++ b/python/scryptomath.py
@@ -139,9 +139,9 @@ def relative_error(result: decimal.Decimal, error: decimal.Decimal):
 
 def error_ln() -> decimal.Decimal:
     """
-    Approximation error of `ln` is bound by 2^-58.45 ~ 3*10^-18.
+    Approximation error of `ln` is bound by 2^-58.45 ~ 2.6*10^-18.
 
-    error_ln = 2^-58.45 ~ 3*10^-18
+    error_ln = 2^-58.45 ~ 2.6*10^-18
     """
     with localcontext() as context:
         context.prec = 40
@@ -150,7 +150,7 @@ def error_ln() -> decimal.Decimal:
 
 def error_exp(value: decimal.Decimal) -> decimal.Decimal:
     """
-    Approxmation error of exp_r(r) is bound by 2^-59 ~ 2*10^-18 with reduced argument r of x.
+    Approxmation error of exp_r(r) is bound by 2^-59 ~ 1.8*10^-18 with reduced argument r of x.
 
     ```
     e^x = 2^k * exp_r'(r)                         with k determined by the argument reduction
@@ -195,13 +195,16 @@ def error_pow(base: decimal.Decimal, exp: decimal.Decimal) -> decimal.Decimal:
     ```
     which is much smaller than one.
 
-    Resulting in:
+    Allowing to separate the error term:
     ```txt
     e'^(ln(x) * y + error_ln * y)
     ~ e'^(ln(x) * y) + e^(ln(x) * y) * error_ln * y
     = e^(ln(x) * y) + error_exp(ln(x) * y) + e^(ln(x) * y) * error_ln * y
     = e^(ln(x) * y) + error_pow(x, y)
+    ```
 
+    Resulting in:
+    ```
     error_pow(x, y) = error_exp(ln(x) * y) + e^(ln(x) * y) * error_ln * y
     ```
     """

--- a/src/exponential.rs
+++ b/src/exponential.rs
@@ -145,6 +145,7 @@ impl ExponentialPreciseDecimal for PreciseDecimal {
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
+    use test_case::test_case;
 
     #[test]
     fn test_constants() {
@@ -344,5 +345,18 @@ mod tests {
     fn test_exponent_positive_max() {
         assert_eq!(Decimal::MAX.exp(), None);
         assert_eq!(PreciseDecimal::MAX.exp(), None);
+    }
+
+    #[test_case(dec!(0.000000001), dec!(1.000000001000000000), dec!(000000000000000001); "tiny value")]
+    #[test_case(dec!(0.01), dec!(1.010050167084168057), dec!(0.000000000000000001); "small value")]
+    #[test_case(dec!(0.9), dec!(2.459603111156949663), dec!(0.000000000000000003); "value near one")]
+    #[test_case(dec!(0.99), dec!(2.691234472349262289), dec!(0.000000000000000003); "value very near one")]
+    #[test_case(dec!(1.1), dec!(3.004166023946433112), dec!(0.000000000000000006); "value slightly above one")]
+    #[test_case(dec!(4.4), dec!(81.450868664968117444), dec!(0.000000000000000111); "medium value")]
+    #[test_case(dec!(50), dec!(5184705528587072464087.453322933485384827), dec!(8192.000000000000000000); "large value")]
+    fn test_exp_error(value: Decimal, target_result: Decimal, max_error: Decimal) {
+        let result = value.exp().unwrap();
+        let error = (result - target_result).checked_abs().unwrap();
+        assert!(error <= max_error);
     }
 }

--- a/src/logarithm.rs
+++ b/src/logarithm.rs
@@ -210,6 +210,7 @@ mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
     use radix_common_derive::dec;
+    use test_case::test_case;
 
     #[test]
     fn test_constants() {
@@ -447,5 +448,18 @@ mod tests {
             Decimal::MAX.log_base(dec!(8)),
             Some(dec!("43.735098097342492579"))
         );
+    }
+
+    #[test_case(dec!(0.000000001), dec!(-20.723265836946411157), dec!(0.000000000000000002); "tiny value")]
+    #[test_case(dec!(0.01), dec!(-4.605170185988091369), dec!(0.000000000000000002); "small value")]
+    #[test_case(dec!(0.9), dec!(-0.105360515657826302), dec!(0.000000000000000002); "value near one")]
+    #[test_case(dec!(0.99), dec!(-0.010050335853501442), dec!(0.000000000000000002); "value very near one")]
+    #[test_case(dec!(1.1), dec!(0.095310179804324860), dec!(0.000000000000000002); "value slightly above one")]
+    #[test_case(dec!(4.4), dec!(1.481604540924215478), dec!(0.000000000000000002); "medium value")]
+    #[test_case(dec!(50), dec!(3.912023005428146058), dec!(0.000000000000000002); "large value")]
+    fn test_ln_error(value: Decimal, target_result: Decimal, max_error: Decimal) {
+        let result = value.ln().unwrap();
+        let error = (result - target_result).checked_abs().unwrap();
+        assert!(error <= max_error);
     }
 }

--- a/src/power.rs
+++ b/src/power.rs
@@ -132,6 +132,7 @@ mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
     use radix_common_derive::dec;
+    use test_case::test_case;
 
     #[test]
     fn test_pow_exp_zero() {
@@ -240,5 +241,20 @@ mod tests {
             dec!("3.4").pow(dec!("-15.43")),
             Some(dec!("0.000000006299126210"))
         );
+    }
+
+    #[test_case(dec!(0.000000001), dec!(20), dec!(0), dec!(0); "tiny base small exponent")]
+    #[test_case(dec!(0.01), dec!(0.05), dec!(0.794328234724281502), dec!(0.00000000000000001); "small base small exponent")]
+    #[test_case(dec!(0.01), dec!(20), dec!(0), dec!(0); "small base large exponent")]
+    #[test_case(dec!(0.9), dec!(0.05), dec!(0.994745825930531056), dec!(0.000000000000000001); "base near one small exponent")]
+    #[test_case(dec!(0.9), dec!(20), dec!(0.121576654590569288), dec!(0.000000000000000006); "base near one large exponent")]
+    #[test_case(dec!(0.99), dec!(0.05), dec!(0.999497609447741526), dec!(0.000000000000000001); "base very near one small exponent")]
+    #[test_case(dec!(0.99), dec!(20), dec!(0.817906937597230870), dec!(0.00000000000000043); "base very near one large exponent")]
+    #[test_case(dec!(1.1), dec!(50), dec!(117.390852879695316506), dec!(0.000000000000015129); "base slightly above one large exponent")]
+    #[test_case(dec!(4.4), dec!(50), dec!(148810585114249539880786087698064.3291903), dec!(19178810849144331.490338637325164985); "large base large exponent")]
+    fn test_pow_error(base: Decimal, exp: Decimal, target_result: Decimal, max_error: Decimal) {
+        let result = base.pow(exp).unwrap();
+        let error = (result - target_result).checked_abs().unwrap();
+        assert!(error <= max_error);
     }
 }


### PR DESCRIPTION
Adding in-depth error estimation analysis for `ln()`, `exp()` and `pow()` allowing users of the library to reliably estimate the approximation error for their specific use case and handle it with corresponding safety margins.

For `ln()` the error estimate is constant for `exp()` and `pow()` the error depends on the function parameter values.