### PR TITLE
Update to Scrypto 1.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ description = "Math library extending Radix Scrypto with more advanced mathemati
 repository = "https://github.com/ociswap/scrypto-math"
 
 [dependencies]
-radix-rust = "1.2.0"
-radix-common = "1.2.0"
-radix-common-derive = "1.2.0"
+radix-rust = "1.3.0"
+radix-common = "1.3.0"
+radix-common-derive = "1.3.0"
 num-traits = "0.2.19"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrypto_math"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "MIT"
 description = "Math library extending Radix Scrypto with more advanced mathematical operations"

--- a/src/exponential.rs
+++ b/src/exponential.rs
@@ -135,11 +135,12 @@ impl ExponentialPreciseDecimal for PreciseDecimal {
         let exp_r = PreciseDecimal::ONE + r + (r * c) / (dec!(2) - c);
 
         // (3) Scale back
-        let two_pow_k = PreciseDecimal::from_precise_subunits(if self.is_negative() {
+        let two_pow_k_subunits = if self.is_negative() {
             one_subunits >> k.abs() as u32
         } else {
             one_subunits << k as u32 // k <= 130
-        });
+        };
+        let two_pow_k = PreciseDecimal::from_precise_subunits(two_pow_k_subunits);
         Some(two_pow_k * exp_r)
     }
 }

--- a/src/logarithm.rs
+++ b/src/logarithm.rs
@@ -91,7 +91,8 @@ pub trait LogarithmPreciseDecimal {
 /// Reduces the argument x by finding k and f such that
 /// x = 2^k * (1+f)    where  sqrt(2)/2 < 1+f < sqrt(2)
 fn log_reduce_argument(number: PreciseDecimal) -> (i32, PreciseDecimal) {
-    let full_integer = number.0 / PreciseDecimal::ONE.0;
+    let one_subunits = PreciseDecimal::ONE.precise_subunits();
+    let full_integer = number.precise_subunits() / one_subunits;
 
     if full_integer.is_zero() {
         if number >= SQRT_HALF {
@@ -99,8 +100,9 @@ fn log_reduce_argument(number: PreciseDecimal) -> (i32, PreciseDecimal) {
         }
 
         // uses leading zeros of the full big integer to derive k
-        let k = number.0.leading_zeros() as i32 - SQRT_HALF.0.leading_zeros() as i32;
-        let r = number * PreciseDecimal(PreciseDecimal::ONE.0 << k as u32);
+        let k = number.precise_subunits().leading_zeros() as i32
+            - SQRT_HALF.precise_subunits().leading_zeros() as i32;
+        let r = number * PreciseDecimal::from_precise_subunits(one_subunits << k as u32);
 
         if r >= SQRT_HALF {
             return (-k, r);
@@ -113,7 +115,7 @@ fn log_reduce_argument(number: PreciseDecimal) -> (i32, PreciseDecimal) {
     // uses leading zeros of the full big integer to derive k
     // 255 bits only because the first bit is the sign bit
     let k = 255 - full_integer.leading_zeros() as i32; // index highest integer bit
-    let r = number / PreciseDecimal(PreciseDecimal::ONE.0 << k as u32);
+    let r = number / PreciseDecimal::from_precise_subunits(one_subunits << k as u32);
 
     if r <= SQRT {
         return (k, r);

--- a/src/power.rs
+++ b/src/power.rs
@@ -108,14 +108,16 @@ impl PowerPreciseDecimal for PreciseDecimal {
         }
 
         if self.is_negative() {
-            let exp_is_integer =
-                PreciseDecimal(exp.0 / PreciseDecimal::ONE.0 * PreciseDecimal::ONE.0) == exp;
+            let one_subunits = PreciseDecimal::ONE.precise_subunits();
+            let exp_is_integer = PreciseDecimal::from_precise_subunits(
+                exp.precise_subunits() / one_subunits * one_subunits,
+            ) == exp;
             if !exp_is_integer {
                 // special case (23)
                 return None;
             }
             // special case (22)
-            let is_even = (exp.0 / PreciseDecimal::ONE.0).to_i32()? % 2 == 0;
+            let is_even = (exp.precise_subunits() / one_subunits).to_i32()? % 2 == 0;
             let pow = (self.checked_abs()?.ln()? * exp).exp();
             if is_even {
                 return pow;


### PR DESCRIPTION
Refactor to use precise_subunits() and from_precise_subunits() instead of the now private .0 field.